### PR TITLE
Support custom root-level MCP config properties

### DIFF
--- a/src/pages/MCP.tsx
+++ b/src/pages/MCP.tsx
@@ -15,6 +15,14 @@ import {
 
 type ConfigType = 'http' | 'docker' | 'local' | 'npx' | 'uvx' | 'dnx';
 
+type MCPJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | MCPJsonValue[]
+  | { [key: string]: MCPJsonValue };
+
 interface MCPConfig {
   name?: string; // Only used for encoding in URL parameters, not in the actual config
   type?: string;
@@ -23,6 +31,7 @@ interface MCPConfig {
   args?: string[];
   env?: Record<string, string>;
   headers?: Record<string, string>;
+  [key: string]: MCPJsonValue | undefined;
 }
 
 interface MCPInput {
@@ -57,6 +66,11 @@ interface StandaloneInput {
   id: string;
   description: string;
   password?: boolean;
+}
+
+interface CustomRootProperty {
+  key: string;
+  value: string;
 }
 
 function MCP() {
@@ -127,6 +141,7 @@ function MCP() {
   
   // Standalone inputs (not tied to headers or env vars)
   const [standaloneInputs, setStandaloneInputs] = useState<StandaloneInput[]>([])
+  const [customRootProperties, setCustomRootProperties] = useState<CustomRootProperty[]>([])
   
   // Import modal state
   const [showImportModal, setShowImportModal] = useState(false)
@@ -141,6 +156,7 @@ function MCP() {
     const config: MCPConfig = {};
     const currentDynamicArgs = dynamicArgs[configType] || [];
     const currentDynamicEnv = dynamicEnv[configType] || [];
+    const customRootResult = getCustomRootPropertiesResult();
     
     // Helper function to get input ID for password fields
     const getInputId = (key: string, customName?: string) => {
@@ -275,8 +291,54 @@ function MCP() {
         }
         break;
     }
+
+    Object.entries(customRootResult.properties).forEach(([key, value]) => {
+      config[key] = value;
+    });
     
     return config;
+  }
+
+  const getCustomRootPropertiesResult = (): {
+    properties: Record<string, MCPJsonValue>
+    error: string | null
+  } => {
+    const properties: Record<string, MCPJsonValue> = {}
+
+    for (let index = 0; index < customRootProperties.length; index++) {
+      const property = customRootProperties[index]
+      const key = property.key.trim()
+      const rawValue = property.value.trim()
+
+      if (!key && !rawValue) {
+        continue
+      }
+
+      if (!key) {
+        return {
+          properties: {},
+          error: `Custom root property #${index + 1} is missing a key.`
+        }
+      }
+
+      if (!rawValue) {
+        return {
+          properties: {},
+          error: `Custom root property "${key}" is missing a JSON value.`
+        }
+      }
+
+      try {
+        properties[key] = JSON.parse(rawValue) as MCPJsonValue
+      } catch {
+        return {
+          properties: {},
+          error: `Custom root property "${key}" has invalid JSON.`
+        }
+      }
+    }
+
+    return { properties, error: null }
   }
 
   const encodeConfig = (config: MCPConfig): string => {
@@ -463,6 +525,20 @@ function MCP() {
     );
   }
 
+  const addCustomRootProperty = () => {
+    setCustomRootProperties(prev => [...prev, { key: '', value: '' }]);
+  }
+
+  const removeCustomRootProperty = (index: number) => {
+    setCustomRootProperties(prev => prev.filter((_, i) => i !== index));
+  }
+
+  const updateCustomRootProperty = (index: number, key: string, value: string) => {
+    setCustomRootProperties(prev =>
+      prev.map((property, i) => (i === index ? { key, value } : property))
+    );
+  }
+
   const resetForm = () => {
     if (!confirm('Are you sure you want to reset all fields? This action cannot be undone.')) {
       return;
@@ -502,6 +578,7 @@ function MCP() {
     // Reset HTTP headers and standalone inputs
     setHttpHeaders([]);
     setStandaloneInputs([]);
+    setCustomRootProperties([]);
 
     // Reset badge generation platforms
     setIncludeVSCode(true);
@@ -565,6 +642,16 @@ function MCP() {
 
       // Set server name
       setServerName(extractedServerName || 'imported-server');
+
+      const knownServerConfigKeys = new Set(['name', 'type', 'url', 'command', 'args', 'env', 'headers']);
+      const importedCustomRootProperties = Object.entries(serverConfig)
+        .filter(([key]) => !knownServerConfigKeys.has(key))
+        .map(([key, value]) => {
+          const serialized = JSON.stringify(value);
+          return serialized === undefined ? null : { key, value: serialized };
+        })
+        .filter((property): property is CustomRootProperty => property !== null);
+      setCustomRootProperties(importedCustomRootProperties);
 
       // Detect configuration type and populate fields
       if (serverConfig.type === 'http') {
@@ -880,6 +967,14 @@ function MCP() {
           [parsed.configType]: envList
         }))
       }
+
+      const importedCustomRootProperties = Object.entries(parsed.additionalRootProps || {})
+        .map(([key, value]) => {
+          const serialized = JSON.stringify(value)
+          return serialized === undefined ? null : { key, value: serialized }
+        })
+        .filter((property): property is CustomRootProperty => property !== null)
+      setCustomRootProperties(importedCustomRootProperties)
     }
     
     // Close search modal
@@ -905,6 +1000,7 @@ function MCP() {
 
   const generateMarkdown = (): string => {
     if (!serverName) return '';
+    if (getCustomRootPropertiesResult().error) return '';
     
     const fullConfig = generateFullConfig();
     const configForBadge: ConfigWithInputs = {
@@ -962,6 +1058,7 @@ function MCP() {
 
   const generateReadmeContent = (): string => {
     if (!serverName) return '';
+    if (getCustomRootPropertiesResult().error) return '';
     
     const fullConfig = generateFullConfig();
     const jsonConfig = JSON.stringify(fullConfig, null, 2);
@@ -1257,7 +1354,8 @@ function MCP() {
     }
   }
 
-  const markdown = generateMarkdown();
+  const customRootPropertiesError = getCustomRootPropertiesResult().error
+  const markdown = customRootPropertiesError ? '' : generateMarkdown();
 
   return (
     <>
@@ -1691,6 +1789,56 @@ function MCP() {
               <span>+</span> Add Input
             </button>
             <small className="field-hint">These inputs will be included in the root inputs array and can be referenced anywhere in your config.</small>
+          </div>
+
+          <div className="form-group">
+            <div className={styles.sectionHeader}>
+              <label>Custom Root Properties</label>
+            </div>
+            <p className="section-description">Add root-level JSON properties to the server config (for example OAuth settings):</p>
+            {customRootProperties.map((property, index) => (
+              <div key={index} className={styles.headerCard}>
+                <div className={styles.dynamicEnvRow}>
+                  <input
+                    type="text"
+                    placeholder="propertyName"
+                    value={property.key}
+                    onChange={(e) => updateCustomRootProperty(index, e.target.value, property.value)}
+                    className={styles.keyInput}
+                  />
+                  <input
+                    type="text"
+                    placeholder='JSON value (e.g., true, 123, "text", {"k":"v"})'
+                    value={property.value}
+                    onChange={(e) => updateCustomRootProperty(index, property.key, e.target.value)}
+                    className={styles.valueInput}
+                  />
+                  <button
+                    type="button"
+                    className={styles.deleteBtn}
+                    onClick={() => removeCustomRootProperty(index)}
+                    aria-label="Remove root property"
+                  >
+                    ✕
+                  </button>
+                </div>
+              </div>
+            ))}
+            <button
+              type="button"
+              className={styles.addBtn}
+              onClick={addCustomRootProperty}
+            >
+              <span>+</span> Add Root Property
+            </button>
+            {customRootPropertiesError && (
+              <small className="field-hint">{customRootPropertiesError}</small>
+            )}
+            {!customRootPropertiesError && (
+              <small className="field-hint">
+                Values are JSON-parsed. Use quotes for string values (for example, "my-client-id").
+              </small>
+            )}
           </div>
 
           <div className="form-group">
@@ -2154,6 +2302,8 @@ function MCP() {
                 </>
               )}
             </>
+          ) : customRootPropertiesError ? (
+            <p className="placeholder">{customRootPropertiesError}</p>
           ) : (
             <p className="placeholder">Fill in the form to generate your badges</p>
           )}

--- a/src/utils/mcpBadgeGenerator.test.ts
+++ b/src/utils/mcpBadgeGenerator.test.ts
@@ -27,6 +27,21 @@ describe('mcpBadgeGenerator', () => {
       
       expect(decoded).toEqual(config);
     });
+
+    it('should encode HTTP config with additional root OAuth fields', () => {
+      const config: MCPConfig = {
+        type: 'http',
+        url: 'https://mcp.slack.com/mcp',
+        oauthClientId: '12348411142.11062036567072',
+        oauthPublicClient: true
+      };
+
+      const encoded = encodeConfig(config);
+      const decoded = JSON.parse(decodeURIComponent(encoded));
+
+      expect(decoded.oauthClientId).toBe('12348411142.11062036567072');
+      expect(decoded.oauthPublicClient).toBe(true);
+    });
     
     it('should encode a Docker config with environment variables', () => {
       const config: MCPConfig = {
@@ -67,6 +82,26 @@ describe('mcpBadgeGenerator', () => {
       expect(decoded.inputs).toBeDefined();
       expect(decoded.inputs).toHaveLength(1);
       expect(decoded.inputs[0].id).toBe('api_key');
+    });
+
+    it('should preserve object and array custom root fields', () => {
+      const config: MCPConfig = {
+        command: 'npx',
+        args: ['-y', 'test-package'],
+        env: {},
+        metadata: {
+          retries: 3,
+          tags: ['alpha', 'beta']
+        }
+      };
+
+      const encoded = encodeConfig(config);
+      const decoded = JSON.parse(decodeURIComponent(encoded));
+
+      expect(decoded.metadata).toEqual({
+        retries: 3,
+        tags: ['alpha', 'beta']
+      });
     });
   });
   

--- a/src/utils/mcpBadgeGenerator.ts
+++ b/src/utils/mcpBadgeGenerator.ts
@@ -10,6 +10,23 @@ import type { BadgeTheme } from '../types/badgeTheme';
 
 export type ConfigType = 'http' | 'docker' | 'local' | 'npx' | 'uvx' | 'dnx';
 
+export interface MCPInput {
+  type: 'promptString';
+  id: string;
+  description: string;
+  password?: boolean;
+}
+
+export type MCPJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | MCPJsonValue[]
+  | { [key: string]: MCPJsonValue }
+  | MCPInput
+  | MCPInput[];
+
 export interface MCPConfig {
   name?: string;
   type?: string;
@@ -18,13 +35,7 @@ export interface MCPConfig {
   args?: string[];
   env?: Record<string, string>;
   headers?: Record<string, string>;
-}
-
-export interface MCPInput {
-  type: 'promptString';
-  id: string;
-  description: string;
-  password?: boolean;
+  [key: string]: MCPJsonValue | undefined;
 }
 
 export interface FullMCPConfig {

--- a/src/utils/mcpRegistryApi.test.ts
+++ b/src/utils/mcpRegistryApi.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { parseRuntimeConfig, type MCPServerRuntime } from './mcpRegistryApi'
+
+describe('parseRuntimeConfig', () => {
+  it('preserves additional HTTP root runtime properties', () => {
+    const runtime: MCPServerRuntime = {
+      type: 'http',
+      url: 'https://mcp.slack.com/mcp',
+      oauthClientId: '12348411142.11062036567072',
+      oauthPublicClient: true
+    }
+
+    const parsed = parseRuntimeConfig(runtime)
+
+    expect(parsed).toBeTruthy()
+    expect(parsed?.configType).toBe('http')
+    expect(parsed?.additionalRootProps).toEqual({
+      oauthClientId: '12348411142.11062036567072',
+      oauthPublicClient: true
+    })
+  })
+
+  it('preserves additional stdio root runtime properties', () => {
+    const runtime: MCPServerRuntime = {
+      command: 'npx',
+      args: ['-y', '@scope/server'],
+      env: {},
+      startupTimeoutMs: 15000
+    }
+
+    const parsed = parseRuntimeConfig(runtime)
+
+    expect(parsed).toBeTruthy()
+    expect(parsed?.configType).toBe('npx')
+    expect(parsed?.additionalRootProps).toEqual({
+      startupTimeoutMs: 15000
+    })
+  })
+})

--- a/src/utils/mcpRegistryApi.ts
+++ b/src/utils/mcpRegistryApi.ts
@@ -16,6 +16,7 @@ export interface MCPServerRuntime {
   type?: 'http' | 'stdio'
   url?: string
   headers?: Record<string, string>
+  [key: string]: unknown
 }
 
 export interface MCPServerMetadata {
@@ -255,17 +256,26 @@ export function parseRuntimeConfig(runtime?: MCPServerRuntime): {
   localArgs?: string
   env?: Record<string, string>
   headers?: Record<string, string>
+  additionalRootProps?: Record<string, unknown>
 } | null {
   if (!runtime) {
     return null
   }
+
+  const knownRuntimeKeys = new Set(['command', 'args', 'env', 'type', 'url', 'headers'])
+  const additionalRootProps = Object.fromEntries(
+    Object.entries(runtime).filter(([key]) => !knownRuntimeKeys.has(key))
+  )
+  const additionalProps =
+    Object.keys(additionalRootProps).length > 0 ? { additionalRootProps } : {}
 
   // HTTP server
   if (runtime.type === 'http' || runtime.url) {
     return {
       configType: 'http',
       serverUrl: runtime.url || '',
-      headers: runtime.headers
+      headers: runtime.headers,
+      ...additionalProps
     }
   }
 
@@ -279,7 +289,8 @@ export function parseRuntimeConfig(runtime?: MCPServerRuntime): {
       return {
         configType: 'npx',
         npxPackage: args[args.indexOf('-y') + 1] || args[1] || args[0] || '',
-        env: runtime.env
+        env: runtime.env,
+        ...additionalProps
       }
     }
 
@@ -291,13 +302,15 @@ export function parseRuntimeConfig(runtime?: MCPServerRuntime): {
           configType: 'uvx',
           uvxFrom: args[fromIndex + 1] || '',
           uvxPackage: args[fromIndex + 2] || '',
-          env: runtime.env
+          env: runtime.env,
+          ...additionalProps
         }
       }
       return {
         configType: 'uvx',
         uvxPackage: args[0] || '',
-        env: runtime.env
+        env: runtime.env,
+        ...additionalProps
       }
     }
 
@@ -306,7 +319,8 @@ export function parseRuntimeConfig(runtime?: MCPServerRuntime): {
       return {
         configType: 'dnx',
         dnxPackage: args[0] || '',
-        env: runtime.env
+        env: runtime.env,
+        ...additionalProps
       }
     }
 
@@ -325,7 +339,8 @@ export function parseRuntimeConfig(runtime?: MCPServerRuntime): {
       return {
         configType: 'docker',
         dockerImage,
-        env: runtime.env
+        env: runtime.env,
+        ...additionalProps
       }
     }
 
@@ -334,7 +349,8 @@ export function parseRuntimeConfig(runtime?: MCPServerRuntime): {
       configType: 'local',
       localCommand: runtime.command,
       localArgs: args.join(', '),
-      env: runtime.env
+      env: runtime.env,
+      ...additionalProps
     }
   }
 


### PR DESCRIPTION
## Why
Some MCP servers require additional root-level fields that are not part of the fixed schema, such as `oauthClientId` and `oauthPublicClient`. Those fields were previously dropped by the MCP page, so generated badges and config output could not represent valid server setups.

## What changed
- Added JSON-typed custom root property support to the MCP page for all config types.
- Added a new UI section to define root property key/value pairs, with JSON parsing and inline validation errors.
- Merged custom root properties into generated server config so badges, CLI commands, `mcp.json`, and README output include them.
- Preserved unknown root fields during JSON import and MCP registry runtime import.
- Expanded typing in MCP config utilities to support additional JSON-typed root fields safely.
- Added tests for OAuth-style root fields and runtime parsing of additional root properties.

## Notes for reviewers
- Custom root values are parsed as JSON, so string values must be entered with quotes (for example, `"client-id"`).
- Invalid JSON blocks generated output until corrected, to avoid producing malformed config payloads.

## Validation
- `npm run lint`
- `npm run test:unit:run`
- `npm run build`